### PR TITLE
output of primary blob endpoint is been added

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,11 @@ output "default_storage_account_primary_web_endpoint" {
   description = "The endpoint URL for web storage in the primary location."
 }
 
+output "default_storage_account_primary_blob_endpoint" {
+  value       = join("", azurerm_storage_account.default_storage.*.primary_blob_endpoint)
+  description = "The endpoint URL for blob storage in the primary location."
+}
+
 output "default_storage_account_primary_web_host" {
   value       = join("", azurerm_storage_account.default_storage.*.primary_web_host)
   description = "The hostname with port if applicable for web storage in the primary location."


### PR DESCRIPTION
## what
* Output of the blob endpoint is added to the output.tf file.

## why
* Blob endpoint parameter was needed in the project while creating the mssql server while enabling sql server auditing policy.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
