### PR TITLE
[Feature] fix - Changed naming convension of private endpoint and private service connection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -229,13 +229,13 @@ provider "azurerm" {
 
 resource "azurerm_private_endpoint" "pep" {
   count               = var.enabled && var.enable_private_endpoint ? 1 : 0
-  name                = format("%s-pe-storage", module.labels.id)
+  name                = format("%s-%s-pe", module.labels.id, var.storage_account_name)
   location            = local.location
   resource_group_name = local.resource_group_name
   subnet_id           = var.subnet_id
   tags                = module.labels.tags
   private_service_connection {
-    name                           = format("%s-psc-storage", module.labels.id)
+    name                           = format("%s-%s-psc", module.labels.id, var.storage_account_name)
     is_manual_connection           = false
     private_connection_resource_id = var.default_enabled == false ? join("", azurerm_storage_account.storage.*.id) : join("", azurerm_storage_account.default_storage.*.id)
     subresource_names              = ["blob"]


### PR DESCRIPTION
## what
* Changed naming format of private endpoint and private service connection

## why
* Not able to create the multiple storage account with private endpoint enabled in the same vnet and label order.
* We need 2 storage account  in the same vnet for hurodata project.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
