### PR TITLE
Updated Provider Configuration and Removed Depriciated Varibales

### DIFF
--- a/.github/workflows/auto_assignee.yml
+++ b/.github/workflows/auto_assignee.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   assignee:
-    uses: clouddrove/github-shared-workflows/.github/workflows/auto_assignee.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_assignee.yml@master
     secrets:
       GITHUB: ${{ secrets.GITHUB }}
     with:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 jobs:
   auto-merge:
-    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/auto_merge.yml@master
     secrets:
       GITHUB: ${{ secrets.GITHUB }}
     with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   changelog:
-    uses: clouddrove/github-shared-workflows/.github/workflows/changelog.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/changelog.yml@master
     secrets: inherit
     with:
       branch: 'master'

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
 jobs:
   example-basic:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/basic'
   example-complete:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@master
     with:
       working_directory: './examples/complete'
       

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -6,6 +6,6 @@ on:
   workflow_dispatch:
 jobs:
   tf-lint:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-lint.yml@master
     secrets:
       GITHUB: ${{ secrets.GITHUB }}

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   tfsec:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tfsec.yml@1.2.8
+    uses: clouddrove/github-shared-workflows/.github/workflows/tfsec.yml@master
     secrets: inherit
     with:
       working_directory: '.'

--- a/examples/basic/example.tf
+++ b/examples/basic/example.tf
@@ -1,15 +1,13 @@
 provider "azurerm" {
   features {}
-  storage_use_azuread        = true
-  subscription_id            = "01111111111110-11-11-11-11"
-  skip_provider_registration = "true"
+  storage_use_azuread = true
+  subscription_id     = "01111111111110-11-11-11-11"
 }
 
 provider "azurerm" {
   features {}
-  alias                      = "peer"
-  subscription_id            = "01111111111110-11-11-11-11"
-  skip_provider_registration = "true"
+  alias           = "peer"
+  subscription_id = "01111111111110-11-11-11-11"
 }
 
 

--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.112.0"
+      version = ">=3.114.0"
     }
   }
 }

--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -1,16 +1,14 @@
 
 provider "azurerm" {
   features {}
-  storage_use_azuread        = true
-  subscription_id            = "01111111111110-11-11-11-11"
-  skip_provider_registration = "true"
+  storage_use_azuread = true
+  subscription_id     = "01111111111110-11-11-11-11"
 }
 
 provider "azurerm" {
   features {}
-  alias                      = "peer"
-  subscription_id            = "01111111111110-11-11-11-11"
-  skip_provider_registration = "true"
+  alias           = "peer"
+  subscription_id = "01111111111110-11-11-11-11"
 }
 
 
@@ -74,7 +72,7 @@ module "subnet" {
 ##-----------------------------------------------------------------------------
 module "log-analytics" {
   source                           = "clouddrove/log-analytics/azure"
-  version                          = "1.0.1"
+  version                          = "1.1.0"
   name                             = local.name
   environment                      = local.environment
   label_order                      = local.label_order

--- a/examples/complete/version.tf
+++ b/examples/complete/version.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.112.0"
+      version = ">=3.114.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier                      = var.account_tier
   access_tier                       = var.access_tier
   account_replication_type          = var.account_replication_type
-  enable_https_traffic_only         = var.enable_https_traffic_only
+  https_traffic_only_enabled        = var.https_traffic_only_enabled
   min_tls_version                   = var.min_tls_version
   is_hns_enabled                    = var.is_hns_enabled
   sftp_enabled                      = var.sftp_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "account_replication_type" {
   description = "Defines the type of replication to use for this storage account. Valid options are LRS, GRS, RAGRS, ZRS, GZRS and RAGZRS. Changing this forces a new resource to be created when types LRS, GRS and RAGRS are changed to ZRS, GZRS or RAGZRS and vice versa."
 }
 
-variable "enable_https_traffic_only" {
+variable "https_traffic_only_enabled" {
   type        = bool
   default     = true
   description = " Boolean flag which forces HTTPS if enabled, see here for more information."

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,13 @@
 terraform {
-  required_version = ">= 1.7.8"
+  required_version = ">= 1.6.6"
 }
 
 terraform {
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">=3.89.0"
+      source                = "hashicorp/azurerm"
+      configuration_aliases = [azurerm.main_sub, azurerm.dns_sub, azurerm.peer]
+      version               = ">=3.114.0"
     }
   }
 }


### PR DESCRIPTION
**What**
- Fixed provider configuration by removing the alias, which was not recognized by Terraform.
- Updated the minimum Terraform version requirement to` 3.114.0.`
-  Removed ` skip_provider_registration` as it has been deprecated.
-  Replaced `enable_https_traffic_only `with` enable_https_traffic_only` in preparation for azurerm version 4.0, where the previous version will be removed.

**Why**
- These changes ensure compatibility with the latest version of the azurerm provider.

**References**
Related issue: [claranet/terraform-azurerm-storage-account#17](https://github.com/claranet/terraform-azurerm-storage-account/issues/17).
