### PR TITLE
feat: Added new resource & fixed deprications

### DIFF
--- a/examples/complete/example.tf
+++ b/examples/complete/example.tf
@@ -2,13 +2,13 @@
 provider "azurerm" {
   features {}
   storage_use_azuread = true
-  subscription_id     = "01111111111110-11-11-11-11"
+  subscription_id     = "000001-11111-1223-XXX-XXXXXXXXXXXX"
 }
 
 provider "azurerm" {
   features {}
   alias           = "peer"
-  subscription_id = "01111111111110-11-11-11-11"
+  subscription_id = "000001-11111-1223-XXX-XXXXXXXXXXXX"
 }
 
 


### PR DESCRIPTION
## what
* Removed `queue_properties` dynamic block
* Added new resource named as `azurerm_storage_account_queue_properties`
* Removed `storage_account_name` variable & added `storage_account_id`

## why
* `storage_account_name` is deprecated and superseded by `storage_account_id` 
* `queue_properties ` block in `azurerm_storage_account` resource is superseded by new resource `azurerm_storage_account_queue_properties`

## references
* [storage - add support for storage_account_id to azurerm_storage_container and azurerm_storage_share](https://github.com/hashicorp/terraform-provider-azurerm/pull/27733)
* [storage - allow azurerm_storage_account to be used in Data Plane restrictive environments ](https://github.com/hashicorp/terraform-provider-azurerm/pull/27818)
