### PR TITLE
fix: Updated Container Depreciated Attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -366,7 +366,7 @@ resource "azurerm_storage_container" "container" {
   provider              = azurerm.main_sub
   count                 = var.enabled ? length(var.containers_list) : 0
   name                  = var.containers_list[count.index].name
-  storage_account_name  = var.storage_account_name
+  storage_account_id    = azurerm_storage_account.storage[0].id
   container_access_type = var.containers_list[count.index].access_type
 }
 


### PR DESCRIPTION
## what
- Removed Storage Account name and replaced with Storage Account ID in Container List 

## why
- Attribute will be removed in AzureRM 5.0 Version